### PR TITLE
Remove unused import.

### DIFF
--- a/src/static/build.rs
+++ b/src/static/build.rs
@@ -3,7 +3,6 @@ extern crate cc;
 
 use std::env;
 use std::path::PathBuf;
-use std::process::Command;
 
 fn main() {
     // Sequential C support


### PR DESCRIPTION
This fixes a pesky downstream build warning.