### PR TITLE
Supply more Cargo fields, and don't break when building OpenCL lib on MacOS 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,9 @@ Inflector = "0.11.4"
 regex = "1"
 structopt = "0.3.2"
 
-
 [features]
 default = ["sequential_c"]
 sequential_c = []
 cuda = []
 opencl = []
 no_futhark = []
-

--- a/examples/codegen.rs
+++ b/examples/codegen.rs
@@ -1,3 +1,13 @@
+extern crate genfut;
+use genfut::Opt;
+
 fn main() {
-    genfut::genfut("matmul", "matmul.fut")
+    genfut::genfut(Opt {
+        name: "matmul".to_string(),
+        file: std::path::PathBuf::from("matmul.fut"),
+        author: "Name <name@example.com>".to_string(),
+        version: "0.1.0".to_string(),
+        license: "YOLO".to_string(),
+        description: "Futhark matrix multiplication example".to_string(),
+    })
 }

--- a/examples/matmul/Cargo.toml
+++ b/examples/matmul/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "matmul"
+description = "Futhark matrix multiplication example"
 version = "0.1.0"
 authors = ["Name <name@example.com>"]
 edition = "2018"
+license = "YOLO"
 
 [dependencies]
 

--- a/examples/matmul/build.rs
+++ b/examples/matmul/build.rs
@@ -3,7 +3,6 @@ extern crate cc;
 
 use std::env;
 use std::path::PathBuf;
-use std::process::Command;
 
 fn main() {
     // Sequential C support
@@ -50,7 +49,7 @@ fn main() {
     #[cfg(all(feature = "opencl", target_os = "macos"))]
     println!("cargo:rustc-link-lib=framework=OpenCL");
 
-    #[cfg(feature = "opencl")]
+    #[cfg(all(feature = "opencl", not(target_os = "macos")))]
     let bindings = bindgen::Builder::default()
         .header("./lib/a.h")
         .generate()
@@ -80,6 +79,7 @@ fn main() {
     }
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    #[cfg(not(all(feature = "opencl", target_os = "macos")))]
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,25 +1,7 @@
-use std::path::PathBuf;
-
+use genfut::{genfut, Opt};
 use structopt::StructOpt;
-
-use genfut::genfut;
-
-#[derive(StructOpt, Debug)]
-#[structopt(
-    name = "genfut",
-    about = "Generates rust code to interface with generated futhark code."
-)]
-struct Opt {
-    /// Output dir
-    #[structopt(name = "NAME")]
-    name: String,
-
-    /// File to process
-    #[structopt(name = "FILE", parse(from_os_str))]
-    file: PathBuf,
-}
 
 fn main() {
     let opt = Opt::from_args();
-    genfut(opt.name, opt.file);
+    genfut(opt);
 }

--- a/src/static/build.rs
+++ b/src/static/build.rs
@@ -49,7 +49,7 @@ fn main() {
     #[cfg(all(feature = "opencl", target_os = "macos"))]
     println!("cargo:rustc-link-lib=framework=OpenCL");
 
-    #[cfg(feature = "opencl")]
+    #[cfg(all(feature = "opencl", not(target_os = "macos")))]
     let bindings = bindgen::Builder::default()
         .header("./lib/a.h")
         .generate()
@@ -79,6 +79,7 @@ fn main() {
     }
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    #[cfg(not(all(feature = "opencl", target_os = "macos")))]
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");

--- a/src/static/static_cargo.toml
+++ b/src/static/static_cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "{libname}"
-version = "0.1.0"
-authors = ["Name <name@example.com>"]
+description = "{description}"
+version = "{version}"
+authors = ["{author}"]
 edition = "2018"
+license = "{license}"
 
 [dependencies]
 


### PR DESCRIPTION
The title says it all.

Handling of option inputs could be cleaner, and a much better story for OpenCL on MacOS would be nice. Meanwhile, these changes should at least enable publishing a portable (meaning it won't break the build on MacOS -- not that OpenCL will work there) crate without having to adjust the generated output. 