### PR TITLE
Cleanup warnings

### DIFF
--- a/src/static/build.rs
+++ b/src/static/build.rs
@@ -1,8 +1,5 @@
 extern crate cc;
 
-use std::env;
-use std::path::PathBuf;
-
 fn main() {
     // Sequential C support
     #[cfg(feature = "sequential_c")]

--- a/src/static/static_context.rs
+++ b/src/static/static_context.rs
@@ -2,8 +2,8 @@ use crate::bindings;
 
 #[derive(Clone, Copy)]
 pub struct FutharkContext {
-    context: *mut bindings::futhark_context,
-    config: *mut bindings::futhark_context_config,
+    pub context: *mut bindings::futhark_context,
+    pub config: *mut bindings::futhark_context_config,
 }
 
 // Safe to implement because Futhark has internal synchronization.


### PR DESCRIPTION
This PR cleans up some warnings for unused imports, and makes `FutharkContext` fields public to support calling some API functions.