### PR TITLE
Futhark since 0.15.7 now returns const shapes for arrays.

### DIFF
--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -53,7 +53,7 @@ impl FutharkType for futhark_{rust_type}_{dim}d {{
    type RustType = {rust_type};
    const DIM: usize = {dim};
 
-    unsafe fn shape<C>(ctx: C, ptr: *const bindings::futhark_{rust_type}_{dim}d) -> *mut i64
+    unsafe fn shape<C>(ctx: C, ptr: *const bindings::futhark_{rust_type}_{dim}d) -> *const i64
     where C: Into<*mut bindings::futhark_context>
     {{
         let ctx = ctx.into();

--- a/src/static/static_array.rs
+++ b/src/static/static_array.rs
@@ -5,8 +5,8 @@ use crate::{Error, Result};
 pub(crate) trait FutharkType {
     type RustType: Default;
     const DIM: usize;
-    
-    unsafe fn shape<C>(ctx: C, ptr: *const Self) -> *mut i64
+
+    unsafe fn shape<C>(ctx: C, ptr: *const Self) -> *const i64
     where
         C: Into<*mut bindings::futhark_context>;
     unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)

--- a/src/static/static_array_types.rs
+++ b/src/static/static_array_types.rs
@@ -26,7 +26,7 @@ impl {array_type} {{
         T: Into<*mut bindings::futhark_context>,
     {{
         let ctx = ctx.into();
-        let shape_ptr: *mut i64 = {futhark_type}::shape(ctx, ptr);
+        let shape_ptr: *const i64 = {futhark_type}::shape(ctx, ptr);
         let shape = std::slice::from_raw_parts(shape_ptr, {dim});
         Vec::from(shape)
     }}


### PR DESCRIPTION
This change be backwards-compatible with older versions of Futhark,
but the generated Rust will of course have a different type (but
exploiting the mutability would have lead to havoc in any case).