### PR TITLE
FEAT: Added flag -std=c99 to enable building on older versions of gcc (4.8.5 specifically)

### DIFF
--- a/src/static/build.rs
+++ b/src/static/build.rs
@@ -6,6 +6,7 @@ fn main() {
     cc::Build::new()
         .file("./lib/a.c")
         .flag("-fPIC")
+        .flag("-std=c11")
         .shared_flag(true)
         .warnings(false)
         .compile("a");
@@ -17,6 +18,7 @@ fn main() {
         .cuda(true)
         .flag("-Xcompiler")
         .flag("-fPIC")
+        .flag("-std=c11")
         .flag("-w")
         .shared_flag(true)
         .compile("a");
@@ -37,10 +39,22 @@ fn main() {
             cc::Build::new()
                 .file("./lib/a.c")
                 .flag("-fPIC")
+                .flag("-std=c11")
                 .flag("-lOpenCL")
                 .shared_flag(true)
                 .compile("a");
             println!("cargo:rustc-link-lib=dylib=OpenCL");
+        }
+        #[cfg(target_os = "macos")]
+        {
+            cc::Build::new()
+                .file("./lib/a.c")
+                .flag("-fPIC")
+                .flag("-std=c11")
+                .flag("-framework")
+                .flag("OpenCL")
+                .shared_flag(true)
+                .compile("a");
         }
     }
 }

--- a/src/static/build.rs
+++ b/src/static/build.rs
@@ -6,7 +6,7 @@ fn main() {
     cc::Build::new()
         .file("./lib/a.c")
         .flag("-fPIC")
-        .flag("-std=c11")
+        .flag("-std=c99")
         .shared_flag(true)
         .warnings(false)
         .compile("a");
@@ -18,7 +18,7 @@ fn main() {
         .cuda(true)
         .flag("-Xcompiler")
         .flag("-fPIC")
-        .flag("-std=c11")
+        .flag("-std=c99")
         .flag("-w")
         .shared_flag(true)
         .compile("a");
@@ -39,7 +39,7 @@ fn main() {
             cc::Build::new()
                 .file("./lib/a.c")
                 .flag("-fPIC")
-                .flag("-std=c11")
+                .flag("-std=c99")
                 .flag("-lOpenCL")
                 .shared_flag(true)
                 .compile("a");
@@ -50,7 +50,7 @@ fn main() {
             cc::Build::new()
                 .file("./lib/a.c")
                 .flag("-fPIC")
-                .flag("-std=c11")
+                .flag("-std=c99")
                 .flag("-framework")
                 .flag("OpenCL")
                 .shared_flag(true)

--- a/src/static/build.rs
+++ b/src/static/build.rs
@@ -45,16 +45,5 @@ fn main() {
                 .compile("a");
             println!("cargo:rustc-link-lib=dylib=OpenCL");
         }
-        #[cfg(target_os = "macos")]
-        {
-            cc::Build::new()
-                .file("./lib/a.c")
-                .flag("-fPIC")
-                .flag("-std=c99")
-                .flag("-framework")
-                .flag("OpenCL")
-                .shared_flag(true)
-                .compile("a");
-        }
     }
 }


### PR DESCRIPTION
See https://github.com/filecoin-project/neptune-triton/pull/9 for reference.  

NOTE: I was unable to test due to problems getting getting futhark installed in my environment