### PR TITLE
Don't compile OpenCL on MacOS (for now).

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,8 @@ fn main() -> Result<(), Error> {
     Ok(())
 }
 ```
+### MacOS
+
+For the time being, due to quirks of the total toolchain, MacOS is unsupported. Generated libraries will build on MacOS
+and do not require that OpenCL be installed. However, calling any of the API functions at runtime may result in an
+error, so users of that library should avoid doing so on MacOS.

--- a/src/static/build.rs
+++ b/src/static/build.rs
@@ -42,15 +42,5 @@ fn main() {
                 .compile("a");
             println!("cargo:rustc-link-lib=dylib=OpenCL");
         }
-        #[cfg(target_os = "macos")]
-        {
-            cc::Build::new()
-                .file("./lib/a.c")
-                .flag("-fPIC")
-                .flag("-framework")
-                .flag("OpenCL")
-                .shared_flag(true)
-                .compile("a");
-        }
     }
 }


### PR DESCRIPTION
Since the MacOS OpenCL bindings aren't working yet anyway, never try to compile on MacOS. This is causing some downstream builds which don't have OpenCL installed properly to fail.