### PR TITLE
Add FutharkContext::free.

### DIFF
--- a/src/static/static_context.rs
+++ b/src/static/static_context.rs
@@ -25,6 +25,13 @@ impl FutharkContext {
     pub(crate) fn ptr(&mut self) -> *mut bindings::futhark_context {
         self.context
     }
+
+    pub fn free(&mut self) {
+        unsafe {
+            bindings::futhark_context_free(self.context);
+            bindings::futhark_context_config_free(self.config);
+        }
+    }
 }
 
 impl From<FutharkContext> for *mut bindings::futhark_context {


### PR DESCRIPTION
Closes #15 .

I tried to implement `Drop` for `FutharkContext` as suggested in the issue. However, removing the `Copy` trait (as required) led to compilation errors in the `Array_::from_vec` methods. I am not certain there is no way around this, but I was not able to figure anything out after some rooting around.

Consumers for whom an RAII-based cleanup makes sense can use `free` in an appropriate `Drop` implementation. In the specific case of `neptune-triton`, we only ever allocate a single `FutharkContext` per device (per process) — which is another strategy to avoid leaking contexts.