### PR TITLE
Remove Copy from FutharkContext

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -6,10 +6,10 @@ fn main() -> Result<(), Error> {
     let a = vec![1, 2, 3, 4];
     let b = vec![2, 3, 4, 1];
 
-    let mut ctx = FutharkContext::new();
+    let ctx = FutharkContext::new();
 
-    let a_arr = Array_i32_2d::from_vec(ctx, &a, &vec![2, 2])?;
-    let b_arr = Array_i32_2d::from_vec(ctx, &b, &vec![2, 2])?;
+    let a_arr = Array_i32_2d::from_vec(&ctx, &a, &vec![2, 2])?;
+    let b_arr = Array_i32_2d::from_vec(&ctx, &b, &vec![2, 2])?;
 
     let res_arr = ctx.matmul(a_arr, b_arr)?;
 

--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -38,7 +38,7 @@ fn gen_impl_futhark_type(input: &str) -> String {
     write!(&mut buffer,
 r#"
 impl futhark_{rust_type}_{dim}d {{
-   unsafe fn new(ctx: &FutharkContext, arr: &[i32], dim: &[i64]) -> *const Self
+   unsafe fn new(ctx: &crate::context::FutharkContext, arr: &[{rust_type}], dim: &[i64]) -> *const Self
    {{
      let ctx = ctx.ptr();
      bindings::futhark_new_{rust_type}_{dim}d(
@@ -52,19 +52,19 @@ impl FutharkType for futhark_{rust_type}_{dim}d {{
    type RustType = {rust_type};
    const DIM: usize = {dim};
 
-    unsafe fn shape(ctx: &FutharkContext, ptr: *const bindings::futhark_{rust_type}_{dim}d) -> *const i64
+    unsafe fn shape(ctx: &crate::context::FutharkContext, ptr: *const bindings::futhark_{rust_type}_{dim}d) -> *const i64
     {{
         let ctx = ctx.ptr();
         bindings::futhark_shape_{rust_type}_{dim}d(ctx, ptr as *mut bindings::futhark_{rust_type}_{dim}d)
     }}
-    unsafe fn values(ctx: &FutharkContext, ptr: *mut Self, dst: *mut Self::RustType)
+    unsafe fn values(ctx: &crate::context::FutharkContext, ptr: *mut Self, dst: *mut Self::RustType)
     {{
         let ctx = ctx.ptr();
         bindings::futhark_values_{rust_type}_{dim}d(ctx, ptr, dst);
         // Sync the values to the array.
         bindings::futhark_context_sync(ctx);
     }}
-    unsafe fn free(ctx: &FutharkContext, ptr: *mut Self)
+    unsafe fn free(ctx: &crate::context::FutharkContext, ptr: *mut Self)
     {{
         let ctx = ctx.ptr();
         bindings::futhark_free_{rust_type}_{dim}d(ctx, ptr);

--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -38,10 +38,9 @@ fn gen_impl_futhark_type(input: &str) -> String {
     write!(&mut buffer,
 r#"
 impl futhark_{rust_type}_{dim}d {{
-   unsafe fn new<C>(ctx: C, arr: &[{rust_type}], dim: &[i64]) -> *const Self
-   where C: Into<*mut bindings::futhark_context>
+   unsafe fn new(ctx: &FutharkContext, arr: &[i32], dim: &[i64]) -> *const Self
    {{
-     let ctx = ctx.into();
+     let ctx = ctx.ptr();
      bindings::futhark_new_{rust_type}_{dim}d(
        ctx,
        arr.as_ptr() as *mut {rust_type},
@@ -53,24 +52,21 @@ impl FutharkType for futhark_{rust_type}_{dim}d {{
    type RustType = {rust_type};
    const DIM: usize = {dim};
 
-    unsafe fn shape<C>(ctx: C, ptr: *const bindings::futhark_{rust_type}_{dim}d) -> *const i64
-    where C: Into<*mut bindings::futhark_context>
+    unsafe fn shape(ctx: &FutharkContext, ptr: *const bindings::futhark_{rust_type}_{dim}d) -> *const i64
     {{
-        let ctx = ctx.into();
+        let ctx = ctx.ptr();
         bindings::futhark_shape_{rust_type}_{dim}d(ctx, ptr as *mut bindings::futhark_{rust_type}_{dim}d)
     }}
-    unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
-    where C: Into<*mut bindings::futhark_context>
+    unsafe fn values(ctx: &FutharkContext, ptr: *mut Self, dst: *mut Self::RustType)
     {{
-        let ctx = ctx.into();
+        let ctx = ctx.ptr();
         bindings::futhark_values_{rust_type}_{dim}d(ctx, ptr, dst);
         // Sync the values to the array.
         bindings::futhark_context_sync(ctx);
     }}
-    unsafe fn free<C>(ctx: C, ptr: *mut Self)
-    where C: Into<*mut bindings::futhark_context>
+    unsafe fn free(ctx: &FutharkContext, ptr: *mut Self)
     {{
-        let ctx = ctx.into();
+        let ctx = ctx.ptr();
         bindings::futhark_free_{rust_type}_{dim}d(ctx, ptr);
     }}}}"#, rust_type=captures[1].to_owned(), dim=dim, array_dim=array_dim_expansion(dim)
     ).expect("Write failed!");

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -63,7 +63,7 @@ pub(crate) fn gen_entry_point(input: &str) -> (String, String, Vec<String>) {
     let name = re_name.captures(input).unwrap()[1].to_owned();
     let mut buffer = format!("pub fn {name}", name = name);
 
-    write!(&mut buffer, "(&mut self, ");
+    write!(&mut buffer, "(&self, ");
     for (i, (argtype, argname)) in arg_pairs.iter().enumerate() {
         if argname.starts_with("in") {
             let argtype_string = type_translation(String::from(argtype.clone()));
@@ -101,7 +101,7 @@ pub(crate) fn gen_entry_point(input: &str) -> (String, String, Vec<String>) {
 
     write!(
         &mut buffer,
-        "{{\nlet ctx = self.ptr();\nunsafe{{\n_{name}(ctx, ",
+        "{{\nunsafe{{\n_{name}(self, ",
         name = name
     );
     for (i, (argtype, argname)) in arg_pairs.iter().enumerate() {
@@ -119,7 +119,7 @@ pub(crate) fn gen_entry_point(input: &str) -> (String, String, Vec<String>) {
     let mut buffer2 = String::new();
     write!(
         &mut buffer2,
-        "unsafe fn _{name}(ctx: *mut bindings::futhark_context, ",
+        "unsafe fn _{name}(ctx: &FutharkContext, ",
         name = name
     );
     for (i, (argtype, argname)) in arg_pairs.iter().enumerate() {
@@ -158,7 +158,7 @@ pub(crate) fn gen_entry_point(input: &str) -> (String, String, Vec<String>) {
 
     write!(
         &mut buffer2,
-        "\nif bindings::futhark_entry_{name}(ctx, ",
+        "\nif bindings::futhark_entry_{name}(ctx.ptr(), ",
         name = name
     );
     for (i, (argtype, argname)) in arg_pairs.iter().enumerate() {
@@ -174,7 +174,7 @@ pub(crate) fn gen_entry_point(input: &str) -> (String, String, Vec<String>) {
     writeln!(
         &mut buffer2,
         ") != 0 {{
-return Err(FutharkError::new(ctx).into());}}"
+return Err(FutharkError::new(ctx.ptr()).into());}}"
     );
 
     let mut opaque_types = Vec::new();

--- a/src/static/static_array.rs
+++ b/src/static/static_array.rs
@@ -1,13 +1,12 @@
 use crate::bindings;
 use crate::traits::*;
 use crate::{Error, Result};
-use crate::context::FutharkContext;
 
 pub(crate) trait FutharkType {
     type RustType: Default;
     const DIM: usize;
 
-    unsafe fn shape(ctx: &FutharkContext, ptr: *const Self) -> *const i64;
-    unsafe fn values(ctx: &FutharkContext, ptr: *mut Self, dst: *mut Self::RustType);
-    unsafe fn free(ctx: &FutharkContext, ptr: *mut Self);
+    unsafe fn shape(ctx: &crate::context::FutharkContext, ptr: *const Self) -> *const i64;
+    unsafe fn values(ctx: &crate::context::FutharkContext, ptr: *mut Self, dst: *mut Self::RustType);
+    unsafe fn free(ctx: &crate::context::FutharkContext, ptr: *mut Self);
 }

--- a/src/static/static_array.rs
+++ b/src/static/static_array.rs
@@ -1,18 +1,13 @@
 use crate::bindings;
 use crate::traits::*;
 use crate::{Error, Result};
+use crate::context::FutharkContext;
 
 pub(crate) trait FutharkType {
     type RustType: Default;
     const DIM: usize;
 
-    unsafe fn shape<C>(ctx: C, ptr: *const Self) -> *const i64
-    where
-        C: Into<*mut bindings::futhark_context>;
-    unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
-    where
-        C: Into<*mut bindings::futhark_context>;
-    unsafe fn free<C>(ctx: C, ptr: *mut Self)
-    where
-        C: Into<*mut bindings::futhark_context>;
+    unsafe fn shape(ctx: &FutharkContext, ptr: *const Self) -> *const i64;
+    unsafe fn values(ctx: &FutharkContext, ptr: *mut Self, dst: *mut Self::RustType);
+    unsafe fn free(ctx: &FutharkContext, ptr: *mut Self);
 }

--- a/src/static/static_array_types.rs
+++ b/src/static/static_array_types.rs
@@ -1,7 +1,7 @@
 #[derive(Debug)]
 pub struct {array_type}<'a> {{
     ptr: *const {futhark_type},
-    ctx: &'a FutharkContext,
+    ctx: &'a crate::context::FutharkContext,
 }}
 
 
@@ -13,19 +13,19 @@ impl<'a> {array_type}<'a> {{
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut {futhark_type} {{
          self.ptr as *mut {futhark_type}
     }}
-    pub(crate) unsafe fn from_ptr(ctx: &'a FutharkContext, ptr: *const {futhark_type}) -> Self
+    pub(crate) unsafe fn from_ptr(ctx: &'a crate::context::FutharkContext, ptr: *const {futhark_type}) -> Self
     {{
         Self {{ ptr, ctx }}
     }}
 
-    pub(crate) unsafe fn shape(ctx: &FutharkContext, ptr: *const {futhark_type}) -> Vec<i64>
+    pub(crate) unsafe fn shape(ctx: &crate::context::FutharkContext, ptr: *const {futhark_type}) -> Vec<i64>
     {{
         let shape_ptr: *const i64 = {futhark_type}::shape(ctx, ptr);
         let shape = std::slice::from_raw_parts(shape_ptr, {dim});
         Vec::from(shape)
     }}
 
-    pub fn from_vec(ctx: &'a FutharkContext, arr: &[{inner_type}], dim: &[i64]) -> Result<Self>
+    pub fn from_vec(ctx: &'a crate::context::FutharkContext, arr: &[{inner_type}], dim: &[i64]) -> Result<Self>
     {{
         let expected = (dim.iter().fold(1, |acc, e| acc * e)) as usize;
         if arr.len() != expected {{

--- a/src/static/static_context.rs
+++ b/src/static/static_context.rs
@@ -1,6 +1,6 @@
 use crate::bindings;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Debug)]
 pub struct FutharkContext {
     pub context: *mut bindings::futhark_context,
     pub config: *mut bindings::futhark_context_config,
@@ -22,13 +22,24 @@ impl FutharkContext {
         }
     }
 
-    pub(crate) fn ptr(&mut self) -> *mut bindings::futhark_context {
-        self.context
+    pub(crate) fn ptr(&self) -> *mut bindings::futhark_context {
+        unsafe {
+            std::mem::transmute(self.context)
+        }
     }
 }
 
 impl From<FutharkContext> for *mut bindings::futhark_context {
-    fn from(mut ctx: FutharkContext) -> Self {
+    fn from(ctx: FutharkContext) -> Self {
         ctx.ptr()
+    }
+}
+
+impl Drop for FutharkContext {
+    fn drop(&mut self) {
+        unsafe {
+            bindings::futhark_context_free(self.context);
+            bindings::futhark_context_config_free(self.config);
+        }
     }
 }

--- a/src/static/static_context.rs
+++ b/src/static/static_context.rs
@@ -1,6 +1,6 @@
 use crate::bindings;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct FutharkContext {
     pub context: *mut bindings::futhark_context,
     pub config: *mut bindings::futhark_context_config,

--- a/src/static/static_opaque_types.rs
+++ b/src/static/static_opaque_types.rs
@@ -1,10 +1,12 @@
+use crate::context::FutharkContext;
+
 #[derive(Debug)]
-pub struct {opaque_type} {{
+pub struct {opaque_type}<'a> {{
     ptr: *const {futhark_type},
-    ctx: *mut bindings::futhark_context,
+    ctx: &'a FutharkContext,
 }}
 
-impl {opaque_type} {{
+impl<'a> {opaque_type}<'a> {{
     pub(crate) unsafe fn as_raw(&self) -> *const {futhark_type} {{
          self.ptr
     }}
@@ -12,17 +14,14 @@ impl {opaque_type} {{
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut {futhark_type} {{
          self.ptr as *mut {futhark_type}
     }}
-    pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const {futhark_type}) -> Self
-        where
-        T: Into<*mut bindings::futhark_context>,
+    pub(crate) unsafe fn from_ptr(ctx: &FutharkContext, ptr: *const {futhark_type}) -> Self
     {{
-        let ctx = ctx.into();
         Self {{ ptr, ctx }}
     }}
 
     pub(crate) unsafe fn free_opaque(&mut self)
     {{
-        bindings::futhark_free_{base_type}(self.ctx, self.as_raw_mut());
+        bindings::futhark_free_{base_type}(self.ctx.ptr(), self.as_raw_mut());
     }}
 }}
 

--- a/src/static/static_opaque_types.rs
+++ b/src/static/static_opaque_types.rs
@@ -1,9 +1,7 @@
-use crate::context::FutharkContext;
-
 #[derive(Debug)]
 pub struct {opaque_type}<'a> {{
     ptr: *const {futhark_type},
-    ctx: &'a FutharkContext,
+    ctx: &'a crate::context::FutharkContext,
 }}
 
 impl<'a> {opaque_type}<'a> {{
@@ -14,7 +12,7 @@ impl<'a> {opaque_type}<'a> {{
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut {futhark_type} {{
          self.ptr as *mut {futhark_type}
     }}
-    pub(crate) unsafe fn from_ptr(ctx: &FutharkContext, ptr: *const {futhark_type}) -> Self
+    pub(crate) unsafe fn from_ptr(ctx: &'a crate::context::FutharkContext, ptr: *const {futhark_type}) -> Self
     {{
         Self {{ ptr, ctx }}
     }}
@@ -25,7 +23,7 @@ impl<'a> {opaque_type}<'a> {{
     }}
 }}
 
-impl Drop for {opaque_type} {{
+impl Drop for {opaque_type}<'_> {{
     fn drop(&mut self) {{
         unsafe {{
             self.free_opaque();


### PR DESCRIPTION
This is a breaking change that will make it possible to automatically drop the context. It also has some changes for the generated api.

supersedes #19 
closes #15 