### PR TITLE
Quote braces in static source.

### DIFF
--- a/src/static/static_array_types.rs
+++ b/src/static/static_array_types.rs
@@ -63,10 +63,10 @@ impl {array_type} {{
 
     pub(crate) unsafe fn free_array(&mut self)
     {{
-        if {futhark_type}::free(self.ctx, self.as_raw_mut()) != 0 {
+        if {futhark_type}::free(self.ctx, self.as_raw_mut()) != 0 {{
             panic!("Deallocation of object failed, this should not happen \
                     outside of compiler bugs and driver or hardware malfunction.");
-        }
+        }}
     }}
 }}
 

--- a/src/static/static_opaque_types.rs
+++ b/src/static/static_opaque_types.rs
@@ -22,10 +22,10 @@ impl {opaque_type} {{
 
     pub(crate) unsafe fn free_opaque(&mut self)
     {{
-        if bindings::futhark_free_{base_type}(self.ctx, self.as_raw_mut()) != 0 {
+        if bindings::futhark_free_{base_type}(self.ctx, self.as_raw_mut()) != 0 {{
             panic!("Deallocation of object failed, this should not happen \
                     outside of compiler bugs and driver or hardware malfunction.");
-        }
+        }}
     }}
 }}
 


### PR DESCRIPTION
#21 introduced an error at code-generation time. This fixes it.