### PR TITLE
Update array type regex to account for missing whitespace

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ pub fn genfut(opt: Opt) {
     let headers = std::fs::read_to_string(PathBuf::from(out_dir).join("lib/a.h"))
         .expect("Could not read headers");
 
-    let re_array_types = Regex::new(r"struct (futhark_.+_\d+d) ;").expect("Regex failed!");
+    let re_array_types = Regex::new(r"struct (futhark_.+_\d+d)\s*;").expect("Regex failed!");
     let array_types: Vec<String> = re_array_types
         .captures_iter(&headers)
         .map(|c| c[1].to_owned())


### PR DESCRIPTION
On my machine, using Futhark 0.19.7, the compiler does not emit a space after the declaration of an array type.
This in turn causes the `array_types` Vec in the code I changed to become empty, and crucial machinery for array types is never generated.

This happens even when using the simple example in `examples/`. I've [attached](https://pastebin.com/FkiPKyJ8) the full output of that example using `sequential_c`, see line 49 for an example.

This change just makes that whitespace optional in the regex.