### PR TITLE
Backend selection instead of using features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,11 @@ readme = "README.md"
 repository = "https://github.com/Erk-/genfut"
 
 [dependencies]
-bindgen = "0.54.0"
-cc = "1.0.45"
+bindgen = "0.60.0"
+cc = "1.0.73"
 Inflector = "0.11.4"
 regex = "1"
-structopt = "0.3.2"
+clap = { version = "3.2.4", features = ["derive"] }
 
 [features]
-default = ["sequential_c"]
-sequential_c = []
-multicore_c = []
-ispc = []
-cuda = []
-opencl = []
-no_futhark = []
+default = []

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,7 +3,7 @@ name = "matmul_codegen"
 version = "0.1.0"
 
 [dependencies]
-genfut = { path= "..", default-features=false, features=["sequential_c"] }
+genfut = { path= "..", default-features=false }
 
 [[bin]]
 name="codegen"

--- a/examples/codegen.rs
+++ b/examples/codegen.rs
@@ -1,7 +1,7 @@
 //! Binary to generate the matmul library
 
 extern crate genfut;
-use genfut::{genfut, Opt};
+use genfut::{genfut, Opt, Backend};
 
 fn main() {
     genfut(Opt {
@@ -11,5 +11,6 @@ fn main() {
         version: "0.1.0".to_string(),
         license: "YOLO".to_string(),
         description: "Futhark matrix multiplication example".to_string(),
+        backend: Backend::SequentialC,
     })
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,7 +1,7 @@
 use genfut::{genfut, Opt};
-use structopt::StructOpt;
+use clap::Parser;
 
 fn main() {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
     genfut(opt);
 }

--- a/src/static/static_cargo.toml
+++ b/src/static/static_cargo.toml
@@ -12,7 +12,7 @@ license = "{license}"
 cc = "1.0"
 
 [features]
-default = ["sequential_c"]
+default = ["{backend}"]
 sequential_c = []
 multicore_c = []
 ispc = []


### PR DESCRIPTION
This patch changes such that backend selection is done using a enum
instead of with cargo features, this is to make it more portable as a
binary instead of needing to recompile for every different backend.

This patch also changes structopt to clap and updates various
dependencies since it is a breaking update.