### PR TITLE
Various suggestions for changes and improvements.

### DIFF
--- a/examples/codegen.rs
+++ b/examples/codegen.rs
@@ -1,7 +1,7 @@
 //! Binary to generate the matmul library
 
 extern crate genfut;
-use genfut::{genfut, Opt, Backend};
+use genfut::{genfut, Backend, Opt};
 
 fn main() {
     genfut(Opt {
@@ -9,8 +9,8 @@ fn main() {
         file: std::path::PathBuf::from("matmul.fut"),
         author: "Name <name@example.com>".to_string(),
         version: "0.1.0".to_string(),
-        license: "YOLO".to_string(),
+        license: "MIT".to_string(),
         description: "Futhark matrix multiplication example".to_string(),
-        backend: Backend::SequentialC,
+        backend: Backend::C,
     })
 }

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,5 +1,4 @@
 //! Example of how to use the built matmul library
-
 use matmul::{Array_i32_2d, Error, FutharkContext};
 
 fn main() -> Result<(), Error> {

--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -86,7 +86,6 @@ pub(crate) fn gen_impl_futhark_types(input: &Vec<String>) -> String {
     let mut buffer2 = String::new();
     writeln!(&mut buffer, "use crate::bindings::*;").expect("Write failed!");
     for t in input {
-        println!("{}", t);
         writeln!(&mut buffer, "{}", gen_impl_futhark_type(t)).expect("Write failed!");
         writeln!(&mut buffer2, "{}", gen_specific_type(t)).expect("Write failed!");
     }

--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -87,8 +87,8 @@ pub(crate) fn gen_impl_futhark_types(input: &Vec<String>) -> String {
     writeln!(&mut buffer, "use crate::bindings::*;").expect("Write failed!");
     for t in input {
         println!("{}", t);
-        writeln!(&mut buffer, "{}", gen_impl_futhark_type(&t)).expect("Write failed!");
-        writeln!(&mut buffer2, "{}", gen_specific_type(&t)).expect("Write failed!");
+        writeln!(&mut buffer, "{}", gen_impl_futhark_type(t)).expect("Write failed!");
+        writeln!(&mut buffer2, "{}", gen_specific_type(t)).expect("Write failed!");
     }
     writeln!(&mut buffer, "{}", buffer2).expect("Write failed!");
     buffer

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use inflector::Inflector;
 use regex::Regex;
 
-fn type_translation(input: String) -> String {
+fn type_translation(input: &str) -> String {
     if input.starts_with("futhark") {
         auto_ctor(&input)
     } else {

--- a/src/genc.rs
+++ b/src/genc.rs
@@ -61,16 +61,16 @@ pub(crate) fn gen_c(backend: Backend, in_file: &std::path::Path, out_dir: &std::
         .arg(in_file)
         .output()
         .expect("[gen_c] failed to execute process");
-    println!("Futhark status: {}", output.status);
-    println!(
-        "Futhark stdout: {}",
-        String::from_utf8(output.stdout).unwrap()
-    );
-    println!(
-        "Futhark stderr: {}",
-        String::from_utf8(output.stderr).unwrap()
-    );
     if !output.status.success() {
+        println!(
+            "Futhark stdout: {}",
+            String::from_utf8(output.stdout).unwrap()
+        );
+        println!(
+            "Futhark stderr: {}",
+            String::from_utf8(output.stderr).unwrap()
+        );
+        println!("Futhark status: {}", output.status);
         panic!("Futhark did not run successfully.")
     }
 }

--- a/src/genc.rs
+++ b/src/genc.rs
@@ -1,3 +1,4 @@
+use core::panic;
 use std::fs::create_dir_all;
 use std::io::{self, Write};
 use std::path::PathBuf;
@@ -69,6 +70,9 @@ pub(crate) fn gen_c(backend: Backend, in_file: &std::path::Path, out_dir: &std::
         "Futhark stderr: {}",
         String::from_utf8(output.stderr).unwrap()
     );
+    if !output.status.success() {
+        panic!("Futhark did not run successfully.")
+    }
 }
 
 pub(crate) fn generate_bindings(header: &std::path::Path, out: &std::path::Path) {

--- a/src/genc.rs
+++ b/src/genc.rs
@@ -1,6 +1,5 @@
 use core::panic;
 use std::fs::create_dir_all;
-use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process::Command;
 use std::str::FromStr;

--- a/src/genc.rs
+++ b/src/genc.rs
@@ -63,21 +63,11 @@ pub(crate) fn gen_c(backend: Backend, in_file: &std::path::Path, out_dir: &std::
     println!("Futhark Status: {}", output.status);
     println!(
         "Futhark stdout: {}",
-        output
-            .stdout
-            .iter()
-            .map(|elm| elm.to_string())
-            .collect::<Vec<_>>()
-            .join(",")
+        String::from_utf8(output.stdout).unwrap()
     );
     println!(
         "Futhark stderr: {}",
-        output
-            .stderr
-            .iter()
-            .map(|elm| elm.to_string())
-            .collect::<Vec<_>>()
-            .join(",")
+        String::from_utf8(output.stderr).unwrap()
     );
 }
 

--- a/src/genc.rs
+++ b/src/genc.rs
@@ -60,8 +60,25 @@ pub(crate) fn gen_c(backend: Backend, in_file: &std::path::Path, out_dir: &std::
         .arg(in_file)
         .output()
         .expect("[gen_c] failed to execute process");
-    io::stdout().write_all(&output.stdout).unwrap();
-    io::stderr().write_all(&output.stderr).unwrap();
+    println!("Futhark Status: {}", output.status);
+    println!(
+        "Futhark stdout: {}",
+        output
+            .stdout
+            .iter()
+            .map(|elm| elm.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    println!(
+        "Futhark stderr: {}",
+        output
+            .stderr
+            .iter()
+            .map(|elm| elm.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    );
 }
 
 pub(crate) fn generate_bindings(header: &std::path::Path, out: &std::path::Path) {

--- a/src/genc.rs
+++ b/src/genc.rs
@@ -61,7 +61,7 @@ pub(crate) fn gen_c(backend: Backend, in_file: &std::path::Path, out_dir: &std::
         .arg(in_file)
         .output()
         .expect("[gen_c] failed to execute process");
-    println!("Futhark Status: {}", output.status);
+    println!("Futhark status: {}", output.status);
     println!(
         "Futhark stdout: {}",
         String::from_utf8(output.stdout).unwrap()

--- a/src/genc.rs
+++ b/src/genc.rs
@@ -65,7 +65,7 @@ pub(crate) fn gen_c(backend: Backend, in_file: &std::path::Path, out_dir: &std::
             "Futhark stdout: {}",
             String::from_utf8(output.stdout).unwrap()
         );
-        println!(
+        eprintln!(
             "Futhark stderr: {}",
             String::from_utf8(output.stderr).unwrap()
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,32 @@
+//!# Genfut
+//!
+//!This is a tool to generate a Rust library to interact with exported functions from a Futhark file.
+//!
+//!## Usage
+//!
+//!### As an executable binary
+//!```shell
+//!genfut <Rust lib name> <futhark_file.fut>
+//!```
+//!
+//!### As a library
+//!
+//!`build.rs`
+//!```rust, no_run
+//!use genfut::{Opt, genfut};
+//!
+//!fn main() {
+//!    genfut(Opt {
+//!        name: "<Rust lib name>".to_string(),
+//!        file: std::path::PathBuf::from("futhark_file.fut"),
+//!        author: "Name <name@example.com>".to_string(),
+//!        version: "0.1.0".to_string(),
+//!        license: "YOLO".to_string(),
+//!        description: "Futhark example".to_string(),
+//!    })
+//!}
+//!
+//!```
 #![allow(unused_must_use)]
 #![allow(unused_variables)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,33 +1,3 @@
-//!# Genfut
-//!
-//!This is a tool to generate a Rust library to interact with exported functions from a Futhark file.
-//!
-//!## Usage
-//!
-//!### As an executable binary
-//!```shell
-//!genfut <Rust lib name> <futhark_file.fut>
-//!```
-//!
-//!### As a library
-//!
-//!`build.rs`
-//!```rust, no_run
-//!use genfut::{Opt, genfut};
-//!
-//!fn main() {
-//!    genfut(Opt {
-//!        name: "<Rust lib name>".to_string(),
-//!        file: std::path::PathBuf::from("futhark_file.fut"),
-//!        author: "Name <name@example.com>".to_string(),
-//!        version: "0.1.0".to_string(),
-//!        license: "YOLO".to_string(),
-//!        description: "Futhark example".to_string(),
-//!    })
-//!}
-//!
-//!```
-
 #![allow(unused_must_use)]
 #![allow(unused_variables)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,6 @@ pub fn genfut(opt: Opt) {
     #[cfg(not(feature = "no_futhark"))]
     {
         let mut futhark_cmd = Command::new("futhark");
-        futhark_cmd.arg("pkg").arg("sync");
-        let _ = futhark_cmd.output().expect("failed: futhark pkg sync");
 
         let version_path = PathBuf::from(&out_dir).join("futhark-version.txt");
         let mut version_file =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub struct Opt {
     pub description: String,
 
     /// Backend
-    #[clap(long, name = "BACKEND", default_value = "sequential_c")]
+    #[clap(long, name = "BACKEND", default_value = "c")]
     pub backend: Backend,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,13 +31,13 @@
 #![allow(unused_must_use)]
 #![allow(unused_variables)]
 
+use clap::Parser;
 use std::fs::create_dir_all;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
-use clap::Parser;
 
 use regex::Regex;
 
@@ -46,8 +46,8 @@ mod entry;
 mod genc;
 use crate::arrays::gen_impl_futhark_types;
 use crate::entry::*;
-use crate::genc::{gen_c, generate_bindings};
 pub use crate::genc::Backend;
+use crate::genc::{gen_c, generate_bindings};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about)]
@@ -81,11 +81,7 @@ pub struct Opt {
     pub description: String,
 
     /// Backend
-    #[clap(
-        long,
-        name = "BACKEND",
-        default_value = "sequential_c",
-    )]
+    #[clap(long, name = "BACKEND", default_value = "sequential_c")]
     pub backend: Backend,
 }
 
@@ -119,7 +115,7 @@ pub fn genfut(opt: Opt) {
 
     // Generate C code, Though only headerfiles are needed.
     // In general C files are generated when build at the user.
-    gen_c(opt.backend, &futhark_file, &out_dir);
+    gen_c(opt.backend, futhark_file, out_dir);
 
     // copy futhark file
     if let Err(e) = std::fs::copy(futhark_file, PathBuf::from(out_dir).join("lib/a.fut")) {

--- a/src/static/build.rs
+++ b/src/static/build.rs
@@ -1,5 +1,4 @@
 extern crate cc;
-use std::process::Command;
 
 fn main() {
     // Sequential C support
@@ -8,6 +7,7 @@ fn main() {
         .file("./lib/a.c")
         .flag("-fPIC")
         .flag("-std=c99")
+        .flag("-O3")
         .shared_flag(true)
         .warnings(false)
         .compile("a");
@@ -19,6 +19,7 @@ fn main() {
         .flag("-fPIC")
         .flag("-pthread")
         .flag("-lm")
+        .flag("-O3")
         .flag("-std=c99")
         .shared_flag(true)
         .warnings(false)
@@ -27,10 +28,12 @@ fn main() {
     // Multicore ISPC support
     #[cfg(feature = "ispc")]
     {
-        let mut ispc = Command::new("ispc");
+        let mut ispc = std::process::Command::new("ispc");
         ispc.arg("./lib/a.kernels.ispc")
-            .arg("-o").arg("./lib/a.kernels.o")
+            .arg("-o")
+            .arg("./lib/a.kernels.o")
             .arg("--pic")
+            .arg("-O3")
             .arg("--addressing=64")
             .arg("--target=host");
         ispc.output().expect("Failed to invoke ispc.");
@@ -39,6 +42,7 @@ fn main() {
             .file("./lib/a.c")
             .object("./lib/a.kernels.o")
             .flag("-fPIC")
+            .flag("-O3")
             .flag("-pthread")
             .flag("-lm")
             .flag("-std=c99")
@@ -54,7 +58,8 @@ fn main() {
         .cuda(true)
         .flag("-Xcompiler")
         .flag("-fPIC")
-        .flag("-std=c99")
+        .flag("-std=c++03")
+        .flag("-O3")
         .flag("-w")
         .shared_flag(true)
         .compile("a");
@@ -76,6 +81,7 @@ fn main() {
                 .file("./lib/a.c")
                 .flag("-fPIC")
                 .flag("-std=c99")
+                .flag("-O3")
                 .shared_flag(true)
                 .compile("a");
             println!("cargo:rustc-link-lib=dylib=OpenCL");
@@ -86,6 +92,7 @@ fn main() {
                 .file("./lib/a.c")
                 .flag("-fPIC")
                 .flag("-std=c99")
+                .flag("-O3")
                 .shared_flag(true)
                 .compile("a");
             println!("cargo:rustc-link-lib=framework=OpenCL");

--- a/src/static/build.rs
+++ b/src/static/build.rs
@@ -2,7 +2,7 @@ extern crate cc;
 
 fn main() {
     // Sequential C support
-    #[cfg(feature = "sequential_c")]
+    #[cfg(feature = "c")]
     cc::Build::new()
         .file("./lib/a.c")
         .flag("-fPIC")
@@ -13,7 +13,7 @@ fn main() {
         .compile("a");
 
     // Multicore C support
-    #[cfg(feature = "multicore_c")]
+    #[cfg(feature = "multicore")]
     cc::Build::new()
         .file("./lib/a.c")
         .flag("-fPIC")

--- a/src/static/static_array_types.rs
+++ b/src/static/static_array_types.rs
@@ -4,7 +4,6 @@ pub struct {array_type} {{
     ctx: *mut bindings::futhark_context,
 }}
 
-
 impl {array_type} {{
     pub(crate) unsafe fn as_raw(&self) -> *const {futhark_type} {{
          self.ptr
@@ -52,12 +51,12 @@ impl {array_type} {{
         let ctx = self.ctx;
         unsafe {{
             futhark_context_sync(ctx);
-            let shape = Self::shape(ctx, self.as_raw());
+            let shape = Self::shape(ctx, self.as_raw());      
             let elems = shape.iter().fold(1, |acc, e| acc * e) as usize;
             let mut buffer: Vec<{inner_type}> =
                 vec![{inner_type}::default(); elems];
-            let cint = {futhark_type}::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr())?;
-            Ok((buffer, shape.to_owned()))
+            {futhark_type}::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr())?;
+            Ok((buffer, shape))
         }}
     }}
 

--- a/src/static/static_cargo.toml
+++ b/src/static/static_cargo.toml
@@ -13,8 +13,8 @@ cc = "1.0"
 
 [features]
 default = ["{backend}"]
-sequential_c = []
-multicore_c = []
+c = []
+multicore = []
 ispc = []
 cuda = []
 opencl = []

--- a/src/static/static_context.rs
+++ b/src/static/static_context.rs
@@ -7,9 +7,17 @@ pub struct FutharkContext {
     pub config: *mut bindings::futhark_context_config,
 }
 
+// impl Drop for FutharkContext {
+
+// }
+
 // Safe to implement because Futhark has internal synchronization.
 unsafe impl Sync for FutharkContext {}
 unsafe impl Send for FutharkContext {}
+
+// I recommend adding an implementation of the Drop trait for
+// FutharkContext, which should call futhark_context_free() and
+// futhark_context_config_free() (in that order)
 
 impl FutharkContext {
     pub fn new() -> Result<Self> {
@@ -27,6 +35,13 @@ impl FutharkContext {
             } else {
                 Err(FutharkError::_new(err).into())
             }
+        }
+    }
+
+    pub fn free(&mut self) {
+        unsafe {
+            bindings::futhark_context_free(self.context);
+            bindings::futhark_context_config_free(self.config);
         }
     }
 

--- a/src/static/static_context.rs
+++ b/src/static/static_context.rs
@@ -38,6 +38,10 @@ impl FutharkContext {
         }
     }
 
+    // calling free() will cause any new calls using this context to fail
+    // TODO: free should take Self as an argument, so that the context cannot
+    // be used after having been freed.
+    // See https://github.com/Erk-/genfut/pull/20
     pub fn free(&mut self) {
         unsafe {
             bindings::futhark_context_free(self.context);

--- a/src/static/static_lib.rs
+++ b/src/static/static_lib.rs
@@ -6,6 +6,8 @@
 #![allow(dead_code)]
 #![allow(improper_ctypes)]
 #![allow(unused_imports)]
+#![allow(clippy::double_parens)]
+#![allow(clippy::unnecessary_fold)]
 
 mod arrays;
 pub mod bindings;


### PR DESCRIPTION
* Renames `SequentialC` to `C`, and `MulticoreC` to `Multicore`, in line with Futharks convention. This also simplifies the code in a number of places.
* Unifies the <backend>_gen_c functions by using to_feature() instead of having different functions.
* Removes the "None" backend.
* Simplifies the code in a number of places, and handles some clippy warnings.
* Panics and stops the process if the futhark compilation fails, instead of potentially failing silently.
* Adds optimization flags for the different backends in build.rs.
* Begins an implementation of explicit free(), in order to allow handling of #15. Implementing Drop would require a much more involved rewrite it seems. Being able to explicitly call free() instead might be good enough, and work.

