### PR TITLE
Move src/bin/main.rs -> src/main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use genfut::{genfut, Opt};
 use clap::Parser;
+use genfut::{genfut, Opt};
 
 fn main() {
     let opt = Opt::parse();


### PR DESCRIPTION
With the old name, `cargo install` would install a binary called `main`. Now, cargo will install a binary named `genfut`.